### PR TITLE
Recipe画像保存処理

### DIFF
--- a/src/main/java/jp/co/aivick/app/WebSecurityConfig.java
+++ b/src/main/java/jp/co/aivick/app/WebSecurityConfig.java
@@ -25,7 +25,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http.authorizeRequests()
-			.antMatchers("/signup", "/login", "/password/*", "/index", "recipes/json", "../static/*/*")
+			.antMatchers("/signup", "/login", "/password/*", "/index", "/recipes/json", "/static/*/*")
 			.permitAll()
 			.anyRequest()
 			.authenticated();

--- a/src/main/java/jp/co/aivick/app/WebSecurityConfig.java
+++ b/src/main/java/jp/co/aivick/app/WebSecurityConfig.java
@@ -25,7 +25,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http.authorizeRequests()
-			.antMatchers("/signup", "/login", "/password/*", "/index","recipes/json")
+			.antMatchers("/signup", "/login", "/password/*", "/index", "recipes/json", "../static/*/*")
 			.permitAll()
 			.anyRequest()
 			.authenticated();

--- a/src/main/java/jp/co/aivick/app/controller/RecipeController.java
+++ b/src/main/java/jp/co/aivick/app/controller/RecipeController.java
@@ -36,19 +36,18 @@ public class RecipeController {
 	RecipeService recipeService;
 
 //fileUpload関連メソッド
-	private String getExtension(String filename) {
-		int dot = filename.lastIndexOf(".");
-		if (dot > 0) {
-			return filename.substring(dot).toLowerCase();
-		}
-		return "";
-	}
-
-	private String getUploadFileName(String fileName) {
-
-		return fileName + "_" + DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").format(LocalDateTime.now())
-				+ getExtension(fileName);
-	}
+	/*
+	 * private String getExtension(String filename) { int dot =
+	 * filename.lastIndexOf("."); if (dot > 0) { return
+	 * filename.substring(dot).toLowerCase(); } return ""; }
+	 */
+	/*
+	 * private String getUploadFileName(String fileName) {
+	 * 
+	 * return fileName + "_" +
+	 * DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").format(LocalDateTime.now())
+	 * + getExtension(fileName); }
+	 */
 
 	/*
 	 * private void createDirectory() { Path path = Paths.get("<<apppath/image>>");
@@ -57,13 +56,13 @@ public class RecipeController {
 	 */
 
 	private void savefile(MultipartFile file) {
-		String filename = getUploadFileName(file.getOriginalFilename());
-		Path uploadfile = Paths.get("/uploads/" + filename);
+		String filename = file.getOriginalFilename();
+		Path uploadfile = Paths.get("../../static/uploads/" + filename);
 		try (OutputStream os = Files.newOutputStream(uploadfile, StandardOpenOption.CREATE)) {
 			byte[] bytes = file.getBytes();
 			os.write(bytes);
 		} catch (IOException e) {
-			// エラー処理は省略
+			throw new RuntimeException("error", e);
 		}
 	}
 //ここまで
@@ -84,14 +83,15 @@ public class RecipeController {
 		Recipe recipe = new Recipe();
 		recipe.setName(recipeForm.getName());
 		recipe.setDetail(recipeForm.getDetail());
-
-		if (recipeForm.getImage() != null) {
+		System.out.print("ooooooo");
+		if (recipeForm.getFile() != null) {
+			System.out.print("aaaaaaaa");
 			// 画像関連処理
-			if (recipeForm.getImage().isEmpty()) {
+			if (recipeForm.getFile().isEmpty()) {
 				// エラー処理は省略
 				return "recipes/create.html";
 			}
-			savefile(recipeForm.getImage());
+			savefile(recipeForm.getFile());
 		}
 
 		recipeService.create(recipe, user.getUsername());

--- a/src/main/java/jp/co/aivick/app/controller/RecipeController.java
+++ b/src/main/java/jp/co/aivick/app/controller/RecipeController.java
@@ -1,5 +1,14 @@
 package jp.co.aivick.app.controller;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -25,6 +35,39 @@ public class RecipeController {
 	@Autowired
 	RecipeService recipeService;
 
+//fileUpload関連メソッド
+	private String getExtension(String filename) {
+		int dot = filename.lastIndexOf(".");
+		if (dot > 0) {
+			return filename.substring(dot).toLowerCase();
+		}
+		return "";
+	}
+
+	private String getUploadFileName(String fileName) {
+
+		return fileName + "_" + DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").format(LocalDateTime.now())
+				+ getExtension(fileName);
+	}
+
+	/*
+	 * private void createDirectory() { Path path = Paths.get("<<apppath/image>>");
+	 * if (!Files.exists(path)) { try { Files.createDirectory(path); } catch
+	 * (Exception e) { //エラー処理は省略 } } }
+	 */
+
+	private void savefile(MultipartFile file) {
+		String filename = getUploadFileName(file.getOriginalFilename());
+		Path uploadfile = Paths.get("/uploads/" + filename);
+		try (OutputStream os = Files.newOutputStream(uploadfile, StandardOpenOption.CREATE)) {
+			byte[] bytes = file.getBytes();
+			os.write(bytes);
+		} catch (IOException e) {
+			// エラー処理は省略
+		}
+	}
+//ここまで
+
 	@GetMapping("/create")
 	public String showCreate(Model model) {
 		model.addAttribute("recipeForm", new RecipeForm());
@@ -37,9 +80,20 @@ public class RecipeController {
 		if (bindingResult.hasErrors()) {
 			return "recipes/create.html";
 		}
+
 		Recipe recipe = new Recipe();
 		recipe.setName(recipeForm.getName());
 		recipe.setDetail(recipeForm.getDetail());
+
+		if (recipeForm.getImage() != null) {
+			// 画像関連処理
+			if (recipeForm.getImage().isEmpty()) {
+				// エラー処理は省略
+				return "recipes/create.html";
+			}
+			savefile(recipeForm.getImage());
+		}
+
 		recipeService.create(recipe, user.getUsername());
 		return "redirect:/recipes/create";
 	}

--- a/src/main/java/jp/co/aivick/app/entity/Recipe.java
+++ b/src/main/java/jp/co/aivick/app/entity/Recipe.java
@@ -25,6 +25,9 @@ public class Recipe {
 	@Column(name = "user_id")
 	private Integer user_id;
 
+	@Column(name = "image")
+	private String image;
+
 	public Integer getRecipe_id() {
 		return recipe_id;
 	}
@@ -55,5 +58,13 @@ public class Recipe {
 
 	public void setUser_id(Integer user_id) {
 		this.user_id = user_id;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
 	}
 }

--- a/src/main/java/jp/co/aivick/app/entity/Recipe.java
+++ b/src/main/java/jp/co/aivick/app/entity/Recipe.java
@@ -1,5 +1,7 @@
 package jp.co.aivick.app.entity;
 
+import java.nio.file.Path;
+
 import org.seasar.doma.Column;
 import org.seasar.doma.Entity;
 import org.seasar.doma.GeneratedValue;
@@ -64,7 +66,7 @@ public class Recipe {
 		return image;
 	}
 
-	public void setImage(String image) {
-		this.image = image;
+	public void setImage(Path imageUrl) {
+		this.image = imageUrl.toString();
 	}
 }

--- a/src/main/java/jp/co/aivick/app/form/RecipeForm.java
+++ b/src/main/java/jp/co/aivick/app/form/RecipeForm.java
@@ -12,6 +12,8 @@ public class RecipeForm {
 	@NotEmpty
 	private String detail;
 
+	private String image;
+
 	public Integer getRecipe_id() {
 		return recipe_id;
 	}
@@ -34,6 +36,14 @@ public class RecipeForm {
 
 	public void setDetail(String detail) {
 		this.detail = detail;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
 	}
 
 }

--- a/src/main/java/jp/co/aivick/app/form/RecipeForm.java
+++ b/src/main/java/jp/co/aivick/app/form/RecipeForm.java
@@ -14,7 +14,7 @@ public class RecipeForm {
 	@NotEmpty
 	private String detail;
 
-	private MultipartFile image;
+	private MultipartFile file;
 
 	public Integer getRecipe_id() {
 		return recipe_id;
@@ -40,14 +40,12 @@ public class RecipeForm {
 		this.detail = detail;
 	}
 
-	public MultipartFile getImage() {
-		return image;
+	public MultipartFile getFile() {
+		return file;
 	}
 
-	public void setImage(MultipartFile image) {
-		this.image = image;
+	public void setFile(MultipartFile file) {
+		this.file = file;
 	}
-
-	
 
 }

--- a/src/main/java/jp/co/aivick/app/form/RecipeForm.java
+++ b/src/main/java/jp/co/aivick/app/form/RecipeForm.java
@@ -2,6 +2,8 @@ package jp.co.aivick.app.form;
 
 import javax.validation.constraints.NotEmpty;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public class RecipeForm {
 
 	private Integer recipe_id;
@@ -12,7 +14,7 @@ public class RecipeForm {
 	@NotEmpty
 	private String detail;
 
-	private String image;
+	private MultipartFile image;
 
 	public Integer getRecipe_id() {
 		return recipe_id;
@@ -38,12 +40,14 @@ public class RecipeForm {
 		this.detail = detail;
 	}
 
-	public String getImage() {
+	public MultipartFile getImage() {
 		return image;
 	}
 
-	public void setImage(String image) {
+	public void setImage(MultipartFile image) {
 		this.image = image;
 	}
+
+	
 
 }

--- a/src/main/java/jp/co/aivick/app/service/RecipeService.java
+++ b/src/main/java/jp/co/aivick/app/service/RecipeService.java
@@ -37,6 +37,8 @@ public class RecipeService {
 		newRecipe.setRecipe_id(recipe.getRecipe_id());
 		newRecipe.setName(recipe.getName());
 		newRecipe.setDetail(recipe.getDetail());
+		//setImage()
+		
 
 		int user_id = userDao.findId(userName).getId();
 		newRecipe.setUser_id(user_id);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,5 +21,9 @@ spring.datasource.username=root
 spring.datasource.password=1783
 spring.datasource.driverClassName=com.mysql.jdbc.Driver
 
+spring.servlet.multipart.max-file-size=128MB
+spring.servlet.multipart.max-request-size=128MB
+spring.servlet.multipart.enabled=true
+
 logging.file.path=/tmp/java_lecture/logs
 logging.file.name=apps.log

--- a/src/main/resources/db/migration/V5__add_image_column_into_recipe.sql
+++ b/src/main/resources/db/migration/V5__add_image_column_into_recipe.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `recipe`
+ADD COLUMN `image` varchar(255);

--- a/src/main/resources/templates/recipes/create.html
+++ b/src/main/resources/templates/recipes/create.html
@@ -12,7 +12,7 @@
 		<h2>レシピ登録</h2>
 
 		<form th:action="@{/recipes/create}" method="post"
-			th:object="${recipeForm}">
+			th:object="${recipeForm}" enctype="multipart/form-data">
 			<ul>
 				<li th:each="error: ${#fields.detailedErrors()}"
 					th:text="${error.message}">
@@ -21,11 +21,11 @@
 			<span>名前</span>:　<input type="text" name="name" th:value="*{name}"><br />
 			<span>詳細</span>: <input type="text" name="detail"
 				th:value="*{detail}"><br/>
-			<span>画像</span>: <input type="file" name="image" th:value="*{image}">
+				
+			<span>画像</span>: <input type="file" name="file" th:value="*{image}" />
 			<button type="submit">登録</button>
 			
 		</form>
 	</div>
-
 </body>
 </html>

--- a/src/main/resources/templates/recipes/create.html
+++ b/src/main/resources/templates/recipes/create.html
@@ -18,10 +18,12 @@
 					th:text="${error.message}">
 			</ul>
 
-			<span>名前</span>:<input type="text" name="name" th:value="*{name}"><br />
+			<span>名前</span>:　<input type="text" name="name" th:value="*{name}"><br />
 			<span>詳細</span>: <input type="text" name="detail"
-				th:value="*{detail}">
+				th:value="*{detail}"><br/>
+			<span>画像</span>: <input type="file" name="image" th:value="*{image}">
 			<button type="submit">登録</button>
+			
 		</form>
 	</div>
 

--- a/src/main/resources/templates/recipes/create.html
+++ b/src/main/resources/templates/recipes/create.html
@@ -22,7 +22,7 @@
 			<span>詳細</span>: <input type="text" name="detail"
 				th:value="*{detail}"><br/>
 				
-			<span>画像</span>: <input type="file" name="file" th:value="*{image}" />
+			<span>画像</span>: <input type="file" name="file" />
 			<button type="submit">登録</button>
 			
 		</form>


### PR DESCRIPTION
# 目的
## 画像をアプリケーション内のフォルダに保存し、そのパスを他のレシピ情報と共にDBに保存する。
## タスクを画像の保存と表示で分けることにしました。保存を先にやります。

# 現状
## 一つの投稿フォームで、他の情報と共にコントローラーに送ることは成功した段階。
## 画像がない場合、他の情報だけがDBに保存される（正常な処理ができている）
## 画像がある場合、他の情報だけがDBに保存される
→まだトランザクションに画像の情報を保存する処理を書いていないので当然。
→問題なのは画像がフォルダに保存されていないこと。

# 課題
## 画像保存場所のpath指定
## 保存された画像のパスを取得し、DBに保存するトランザクション